### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/iih-library/src/main/java/me/himanshusoni/iih/ImageUtils.java
+++ b/iih-library/src/main/java/me/himanshusoni/iih/ImageUtils.java
@@ -14,6 +14,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 public class ImageUtils {
+    private ImageUtils() {
+    }
+
     public static String getPackageName(Context c) {
         return c.getPackageName();
     }

--- a/iih-library/src/main/java/me/himanshusoni/iih/UnitUtils.java
+++ b/iih-library/src/main/java/me/himanshusoni/iih/UnitUtils.java
@@ -3,6 +3,9 @@ package me.himanshusoni.iih;
 import android.content.res.Resources;
 
 public class UnitUtils {
+	private UnitUtils() {
+	}
+
 	public static int dpToPx(int dp) {
 		return (int) (dp * Resources.getSystem().getDisplayMetrics().density);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
