### PR TITLE
[squid:S2095] Resources should be closed

### DIFF
--- a/iih-library/src/main/java/me/himanshusoni/iih/ImageUtils.java
+++ b/iih-library/src/main/java/me/himanshusoni/iih/ImageUtils.java
@@ -12,6 +12,7 @@ import android.provider.MediaStore;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 
 public class ImageUtils {
     public static String getPackageName(Context c) {
@@ -128,6 +129,8 @@ public class ImageUtils {
         if (degree <= 0) {
             return imagePath;
         }
+        FileOutputStream fOut = null;
+        FileOutputStream out = null;
         try {
             Bitmap b = BitmapFactory.decodeFile(imagePath);
 
@@ -138,22 +141,35 @@ public class ImageUtils {
                         matrix, true);
             }
 
-            FileOutputStream fOut = new FileOutputStream(imagePath);
+            fOut = new FileOutputStream(imagePath);
             String imageName = imagePath.substring(imagePath.lastIndexOf("/") + 1);
             String imageType = imageName.substring(imageName.lastIndexOf(".") + 1);
 
-            FileOutputStream out = new FileOutputStream(imagePath);
+            out = new FileOutputStream(imagePath);
             if (imageType.equalsIgnoreCase("png")) {
                 b.compress(Bitmap.CompressFormat.PNG, 80, out);
             } else if (imageType.equalsIgnoreCase("jpeg") || imageType.equalsIgnoreCase("jpg")) {
                 b.compress(Bitmap.CompressFormat.JPEG, 80, out);
             }
             fOut.flush();
-            fOut.close();
 
             b.recycle();
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            try {
+                if (fOut != null)
+                    fOut.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        
+            try {
+                if (out != null)
+                    out.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
         return imagePath;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Abdelghany.
